### PR TITLE
Build redistributable app bundles on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,16 @@
-cmake_minimum_required(VERSION 2.8)
-project(Reflection-Keen)
+cmake_minimum_required(VERSION 2.8...3.19)
+project(Reflection-Keen VERSION 0.32.0)
+
+set(bundle_identifier_prefix "net.duke4.ny.refkeen")
+set(bundle_copyright "See README.md for copyright details")
 
 function(add_refkeen_separate_target
 	name app_rc targets libraries sources shared_sources
 	include_dirs common_cc_flags target_cc_flags unified_target_cc_flags is_lib
 )
+	string(REGEX MATCH "-.+$" name_suffix ${name})
+	string(SUBSTRING ${name_suffix} 1 -1 name_suffix)
+
 	set(all_cc_flags ${common_cc_flags})
 	foreach(MACRO ${target_cc_flags})
 		list(APPEND all_cc_flags ${MACRO})
@@ -18,30 +24,61 @@ function(add_refkeen_separate_target
 		add_library(${name} STATIC ${sources})
 		set_target_properties(${name} PROPERTIES COMPILE_FLAGS "${all_cc_flags}")
 	else ()
+		set(icns_file "reflection-${app_rc}.icns")
 		if (WIN32)
 			set(app_rc "rsrc/reflection-${app_rc}.rc")
+		elseif (APPLE)
+			set(app_rc "rsrc/${icns_file}")
+			set_source_files_properties(${app_rc} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 		else ()
 			set(app_rc)
 		endif ()
 		string(REPLACE ";" " " all_cc_flags "${all_cc_flags}")
-		add_executable(${name} ${sources} ${shared_sources} ${app_rc})
-		set_target_properties(${name} PROPERTIES COMPILE_FLAGS "${all_cc_flags}")
+		add_executable(${name} MACOSX_BUNDLE ${sources} ${shared_sources} ${app_rc})
+		set_target_properties(${name} PROPERTIES
+			COMPILE_FLAGS "${all_cc_flags}"
+			MACOSX_BUNDLE_INFO_PLIST "${PROJECT_SOURCE_DIR}/rsrc/Info.plist"
+			MACOSX_BUNDLE_BUNDLE_NAME "ref${name_suffix}"
+			MACOSX_BUNDLE_ICON_FILE "${icns_file}"
+			MACOSX_BUNDLE_GUI_IDENTIFIER "${bundle_identifier_prefix}.${name}"
+			MACOSX_BUNDLE_SHORT_VERSION_STRING "${PROJECT_VERSION}"
+			MACOSX_BUNDLE_BUNDLE_VERSION "${PROJECT_VERSION}"
+			MACOSX_BUNDLE_COPYRIGHT "${bundle_copyright}"
+		)
 		target_link_libraries(${name} ${libraries})
-		set(${targets} "${targets} ${name}" PARENT_SCOPE)
+		list(APPEND targets ${name})
+		set(targets "${targets}" PARENT_SCOPE)
 	endif ()
 	target_include_directories(${name} PUBLIC ${include_dirs})
 endfunction()
 
 function(add_refkeen_unified_target name app_rc targets shared_sources common_cc_flags cc_flags libraries)
+	string(REGEX MATCH "-.+$" name_suffix ${name})
+	string(SUBSTRING ${name_suffix} 1 -1 name_suffix)
+
+	set(icns_file "reflection-${app_rc}.icns")
 	if (WIN32)
 		set(app_rc "rsrc/reflection-${app_rc}.rc")
+	elseif (APPLE)
+		set(app_rc "rsrc/${icns_file}")
+		set_source_files_properties(${app_rc} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 	else ()
 		set(app_rc)
 	endif ()
-	add_executable(${name} ${shared_sources} ${app_rc})
-	set_target_properties(${name} PROPERTIES COMPILE_FLAGS "${common_cc_flags} ${cc_flags}")
+	add_executable(${name} MACOSX_BUNDLE ${shared_sources} ${app_rc})
+	set_target_properties(${name} PROPERTIES
+		COMPILE_FLAGS "${common_cc_flags} ${cc_flags}"
+		MACOSX_BUNDLE_INFO_PLIST "${PROJECT_SOURCE_DIR}/rsrc/Info.plist"
+		MACOSX_BUNDLE_BUNDLE_NAME "ref${name_suffix}"
+		MACOSX_BUNDLE_ICON_FILE "${icns_file}"
+		MACOSX_BUNDLE_GUI_IDENTIFIER "${bundle_identifier_prefix}.${name}"
+		MACOSX_BUNDLE_SHORT_VERSION_STRING "${PROJECT_VERSION}"
+		MACOSX_BUNDLE_BUNDLE_VERSION "${PROJECT_VERSION}"
+		MACOSX_BUNDLE_COPYRIGHT "${bundle_copyright}"
+	)
 	target_link_libraries(${name} ${libraries})
-	set(${targets} "${targets} ${name}" PARENT_SCOPE)
+	list(APPEND targets ${name})
+	set(targets "${targets}" PARENT_SCOPE)
 endfunction()
 
 include(CMakeDependentOption)
@@ -325,7 +362,17 @@ if (BUILD_UNIFIED)
 	)
 endif ()
 
-install(TARGETS ${targets})
-install(FILES "${PROJECT_BINARY_DIR}/refkeen_config.h"
-	DESTINATION include
+include(GNUInstallDirs)
+
+install(TARGETS ${targets}
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	BUNDLE DESTINATION Applications
 )
+
+if (APPLE)
+	include(cmake/MacOSDependencyScan.cmake)
+	set(bundle_dependency_dirs "")
+	macos_dependency_scan(bundle_dependency_dirs ${targets})
+
+	install(CODE "set(bundle_dependency_dirs \"${bundle_dependency_dirs}\")" SCRIPT cmake/MacOSBundle.cmake)
+endif ()

--- a/cmake/MacOSBundle.cmake
+++ b/cmake/MacOSBundle.cmake
@@ -1,0 +1,22 @@
+# Runs at install time to copy in frameworks from the host system if needed.
+# bundle_dependency_dirs should be set by a install(CODE) fragment
+
+if (CMAKE_MINIMUM_REQUIRED_VERSION VERSION_LESS 3.3)
+	cmake_minimum_required(VERSION 3.3)
+endif ()
+
+include(BundleUtilities)
+
+# Pull list of bundles to fixup from the installed files list
+set(bundles "")
+foreach (file IN LISTS CMAKE_INSTALL_MANIFEST_FILES)
+	if (file MATCHES "(.+\\.app)/")
+		if (NOT CMAKE_MATCH_1 IN_LIST bundles)
+			list(APPEND bundles ${CMAKE_MATCH_1})
+		endif ()
+	endif ()
+endforeach ()
+
+foreach (bundle IN LISTS bundles)
+	fixup_bundle($ENV{DESTDIR}${bundle} "" "${bundle_dependency_dirs}")
+endforeach ()

--- a/cmake/MacOSDependencyScan.cmake
+++ b/cmake/MacOSDependencyScan.cmake
@@ -1,0 +1,41 @@
+# Public domain
+
+if (CMAKE_VERSION VERSION_LESS 3.3)
+	function (macos_dependency_scan output)
+		message(WARNING "CMake 3.3 or newer required for macos_dependency_scan to work")
+	endfunction ()
+	return()
+endif ()
+
+# Enable IN_LIST
+cmake_policy(SET CMP0057 NEW)
+
+# Takes targets to scan as additional arguments. The linked libraries on these
+# targets will be scanned for macOS frameworks. The directory that contains
+# these frameworks will be placed in output as well as any frameworks contained
+# within. The output of this function can then be fed into fixup_bundle.
+#
+# This should probably be recursive among detecting other possible ways
+# frameworks could be referenced in the link line, but this should cover the
+# basic use cases and otherwise be harmless.
+function(macos_dependency_scan output)
+	list(POP_FRONT ARGV)
+
+	foreach (target IN LISTS ARGV)
+		get_property(target_links TARGET ${target} PROPERTY LINK_LIBRARIES)
+		foreach (link IN LISTS target_links)
+			if (link MATCHES "^((.*/)[^/]+\\.framework)")
+				set(subframeworks "${CMAKE_MATCH_1}/Versions/Current/Frameworks")
+				set(framework_dir ${CMAKE_MATCH_2})
+				if (IS_DIRECTORY "${subframeworks}" AND NOT subframeworks IN_LIST bundle_dependency_dirs)
+					list(APPEND bundle_dependency_dirs ${subframeworks})
+				endif ()
+				if (NOT framework_dir IN_LIST bundle_dependency_dirs)
+					list(APPEND bundle_dependency_dirs ${framework_dir})
+				endif ()
+			endif ()
+		endforeach()
+	endforeach ()
+
+	set("${output}" "${bundle_dependency_dirs}" PARENT_SCOPE)
+endfunction()

--- a/rsrc/Info.plist
+++ b/rsrc/Info.plist
@@ -5,20 +5,22 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
-	<string>PutAppNameHere</string>
+	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
 	<key>CFBundleIconFile</key>
-	<string>PutAppNameHere.icns</string>
+	<string>${MACOSX_BUNDLE_ICON_FILE}</string>
 	<key>CFBundleIdentifier</key>
-	<string>net.duke4.ny.PutAppNameHere</string>
+	<string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>PutAppNameHere</string>
-	<key>CFBundleVersion</key>
-	<string>PutVerHere</string>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
-	<key>CFBundleSignature</key>
-	<string>PutAppNameHere</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+	<key>CFBundleVersion</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
 </dict>
 </plist>


### PR DESCRIPTION
Note that CMake needs to know the product version number.  It might be ideal to use configure_file to generate a header with that number in it so it's only in one place.