### PR TITLE
Compiler optimization fixes (QA)

### DIFF
--- a/src/kdreams/key_scancode_converters.c
+++ b/src/kdreams/key_scancode_converters.c
@@ -21,7 +21,12 @@
 
 #include "id_heads.h"
 
-/*** SDL scancodes enum copied from SDL_scancode.h (SDL v2.0.2) ***/
+/**
+ * SDL scancodes enum copied from SDL_scancode.h (SDL v2.0.2)
+ *
+ * This represents the possible values for the 2015 Steam release.
+ * Updating this list would be counterproductive.
+ */
 
 /**
  *  \brief The SDL keyboard scancode representation.
@@ -387,7 +392,7 @@ typedef enum
 
     SDL_NUM_SCANCODES = 512 /**< not a key, just marks the number of scancodes
                                  for array bounds */
-} SDL_Scancode;
+} KD_SDL_Scancode;
 
 
 /*** Conversion tables ***/

--- a/src/wolf3d/id_vl.c
+++ b/src/wolf3d/id_vl.c
@@ -611,6 +611,10 @@ void VL_FadeIn (id0_int_t start, id0_int_t end, id0_byte_t id0_far *palette, id0
 {
 	id0_int_t		i,j,delta;
 
+	// Prevent out-of-bound array access in loop
+	const id0_byte_t id0_far * const _palette1 = &palette1[0][0];
+	id0_byte_t id0_far * const _palette2 = &palette2[0][0];
+
 	VL_WaitVBL(1);
 	VL_GetPalette (&palette1[0][0]);
 	memcpy (&palette2[0][0],&palette1[0][0],sizeof(palette1));
@@ -626,8 +630,8 @@ void VL_FadeIn (id0_int_t start, id0_int_t end, id0_byte_t id0_far *palette, id0
 	{
 		for (j=start;j<=end;j++)
 		{
-			delta = palette[j]-palette1[0][j];
-			palette2[0][j] = palette1[0][j] + delta * i / steps;
+			delta = palette[j]-_palette1[j];
+			_palette2[j] = _palette1[j] + delta * i / steps;
 		}
 
 		VL_WaitVBL(1);

--- a/src/wolf3d/mapssdm.h
+++ b/src/wolf3d/mapssdm.h
@@ -1,3 +1,5 @@
+REFKEEN_NS_B
+
 ///////////////////////////////////////
 //
 // TED5 Map Header for SDM
@@ -12,3 +14,5 @@ typedef enum {
 		TUNNELS_2_MAP,           // 1
 		LASTMAP
 	     } mapnames;
+
+REFKEEN_NS_E

--- a/src/wolf3d/mapssod.h
+++ b/src/wolf3d/mapssod.h
@@ -1,3 +1,5 @@
+REFKEEN_NS_B
+
 ///////////////////////////////////////
 //
 // TED5 Map Header for SOD
@@ -31,3 +33,5 @@ typedef enum {
 		ANGEL_OF_DEATH_MAP,      // 20
 		LASTMAP
 	     } mapnames;
+
+REFKEEN_NS_E

--- a/src/wolf3d/mapswl6.h
+++ b/src/wolf3d/mapswl6.h
@@ -1,3 +1,5 @@
+REFKEEN_NS_B
+
 ///////////////////////////////////////
 //
 // TED5 Map Header for WL6
@@ -71,3 +73,5 @@ typedef enum {
 		MAP4L10PATH_MAP,         // 60
 		LASTMAP
 	     } mapnames;
+
+REFKEEN_NS_E


### PR DESCRIPTION
This fixes two kinds of issues: Two One-Definition-Rule (ODR) violations and one out-of-bound (OOB) array access.

ODR errors can cause issues when processing link-time-optimization. Since multiple translation units contain the same symbol but those symbols don't match. This is undefined behavior and while complex linkers will probably still do the right thing (big note on probably), it can lead to runtime errors.

Specifically this was used with `typedef enum { } mapnames` which never get accessed through this symbol anyway (removing `mapnames` is a GNU extension tho and while supported by GCC, Clang and MSVC is thus not standard).
I thus just renamed it to whatever map set it is.

The other ODR violation is `SDL_scancodes`. Now this is technically not even a "different" `typedef enum` just that SDL2 added to it and now they differ. I have not found a single reason why this was copied into the C file in the first place.
Seems to me like that if SDL2 is used anyway it should just be used throughout the project.
Just like every other instance I did use local includes ("" instead of <>)  as I assume this has something to do with the Windows build process and didn't want to dig too deep into this.

The last change is the out-of-bounds access. In the current code the [256][3] 2D array is getting accessed with [0][number between 0 and 767]. This while in theory safe to do is technically out-of-bound access. This by itself isn't a big issue however aggressive loop optimization can lead to undefined behavior. This is obviously besides that accessing the data like this makes the whole 2D array thing pointless.
Now I do admit that this might not be the most elegant solution but since palettes are pointers in the rest of the code  storing the palette as a 2D array brings some issues. It leaves us with a lot of pointer arithmetics or extracting the pointer out of the 2D array anyway. Alternatively one could change the palette to be a 2D array everywhere in the code but that would cause a lot of rewrites for not very much benefit.