### PR TITLE
Add low latency sound option to config

### DIFF
--- a/src/backend/audio/be_audio_init.c
+++ b/src/backend/audio/be_audio_init.c
@@ -93,7 +93,7 @@ void BE_ST_InitAudio(void)
 			BEL_ST_AudioMixerAddSource(
 				OPL_SAMPLE_RATE,
 				// Leave some room for calls to BE_ST_OPL2Write
-				2*samplesForSourceBuffer,
+				BE_Cross_TypedMax(int, samplesForSourceBuffer, OPL_MIN_INPUT_SAMPLES),
 				g_refKeenCfg.oplVol,
 				BEL_ST_GenOPLSamples));
 		g_sdlEmulatedOPLChipReady = true;

--- a/src/backend/audio/be_audio_mixer.c
+++ b/src/backend/audio/be_audio_mixer.c
@@ -220,7 +220,7 @@ uint8_t BEL_ST_GetSBProVolumesFromSource(const BE_ST_AudioMixerSource *src)
 void BEL_ST_AudioMixerCallback(BE_ST_SndSample_T *stream, int len)
 {
 	int samplesToGenerate = len;
-	int samplesToGenerateNextTime = g_stAudioMixer.freq / 100; // ~10ms
+	int samplesToGenerateNextTime = BE_Cross_TypedMin(int, len, g_stAudioMixer.freq / 100); // ~10ms unless buffer is too small
 	int i, j, k;
 	BE_ST_AudioMixerSource *src;
 

--- a/src/backend/audio/be_audio_opl.c
+++ b/src/backend/audio/be_audio_opl.c
@@ -28,6 +28,7 @@
 
 #include "refkeen.h"
 #include "be_audio_mixer.h"
+#include "../timing/be_timing.h"
 #include "nukedopl/opl3.h"
 
 bool g_sdlEmulatedOPLChipReady;
@@ -107,11 +108,14 @@ void BE_ST_OPL2Write(uint8_t reg, uint8_t val)
 	OPL3_WriteReg(&g_oplChip, reg, val);
 	// FIXME: For now we roughly simulate the above delays with a
 	// hack, using a "magic number" that appears to make this work.
-	unsigned int length = OPL_SAMPLE_RATE / 10000;
+	unsigned int length = OPL_WRITE_TIMING_MAGIC_SAMPLES;
 
 	if (length > g_oplMixerSource->in.size - g_oplMixerSource->in.num)
 	{
-		BE_Cross_LogMessage(BE_LOG_MSG_WARNING, "BE_ST_OPL2Write overflow, want %u, have %u\n", length, g_oplMixerSource->in.size - g_oplMixerSource->in.num); // FIXME - other thread
+		// If the timer interrupt isn't running then we expect this buffer isn't
+		// being flushed so we can quietly skip over the timing emulation
+		if (g_sdlTimerIntFuncPtr)
+			BE_Cross_LogMessage(BE_LOG_MSG_WARNING, "BE_ST_OPL2Write overflow, want %u, have %u\n", length, g_oplMixerSource->in.size - g_oplMixerSource->in.num); // FIXME - other thread
 		length = g_oplMixerSource->in.size - g_oplMixerSource->in.num;
 	}
 	if (length)

--- a/src/backend/audio/be_audio_private.h
+++ b/src/backend/audio/be_audio_private.h
@@ -37,6 +37,15 @@
 #define PC_PIT_RATE 1193182
 
 #define OPL_SAMPLE_RATE 49716
+// Number of OPL samples to generate for each register write, for details see
+// comments in BE_ST_OPL2Write.
+#define OPL_WRITE_TIMING_MAGIC_SAMPLES (OPL_SAMPLE_RATE/10000)
+// Number of OPL register writes we need to potentially buffer before audio
+// output gets to flushing.
+#define OPL_WRITE_TIMING_BUFFER 256
+// Minimum number of samples we need to be able to generate to accomplish
+// timing simulation without overflowing.
+#define OPL_MIN_INPUT_SAMPLES (OPL_WRITE_TIMING_MAGIC_SAMPLES*OPL_WRITE_TIMING_BUFFER)
 
 #if (defined REFKEEN_RESAMPLER_LIBSAMPLERATE) || (defined REFKEEN_RESAMPLER_LIBRESAMPLE)
 #define MIXER_SAMPLE_FORMAT_FLOAT

--- a/src/backend/audio/be_audio_sdl.c
+++ b/src/backend/audio/be_audio_sdl.c
@@ -69,6 +69,44 @@ static void BEL_ST_MixerCallback(void *unused_userdata, SDL_AudioStream *stream,
 	}
 }
 
+static void BEL_ST_LowLatencySetup(const SDL_AudioSpec *spec)
+{
+	// As of SDL 3.4 the device sample frames hint doesn't scale based on
+	// sample rate. SDL also at the time of writing has a minimum device
+	// sample rate of 44.1kHz. We could assume the current logic, but we can
+	// also open the device and query what sample rate we got. We do need to
+	// re-open it with adjusted latency.
+	SDL_AudioDeviceID dev = SDL_OpenAudioDevice(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, spec);
+	if (dev == 0)
+	{
+		BE_Cross_LogMessage(BE_LOG_MSG_WARNING, "Cannot temporarily open SDL audio device for low latency probe,\n%s\n", SDL_GetError());
+		return;
+	}
+
+	int sampleRate;
+	SDL_AudioSpec devSpec;
+	if (SDL_GetAudioDeviceFormat(dev, &devSpec, NULL))
+	{
+		sampleRate = devSpec.freq;
+	}
+	else
+	{
+		// If we can't query the actual frequency then we can try just assuming
+		// we will get what we requested.
+		sampleRate = spec->freq;
+	}
+
+	SDL_CloseAudioDevice(dev);
+
+	// Hint that we want 700Hz callback timing
+	char* sampleFramesStr = NULL;
+	if (SDL_asprintf(&sampleFramesStr, "%d", sampleRate/700) != -1)
+	{
+		SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, sampleFramesStr);
+		SDL_free(sampleFramesStr);
+	}
+}
+
 bool BEL_ST_InitAudioSubsystem(int *freq, int *channels, int *bufferLen)
 {
 	SDL_AudioSpec spec;
@@ -84,7 +122,10 @@ bool BEL_ST_InitAudioSubsystem(int *freq, int *channels, int *bufferLen)
 	spec.format = SDL_AUDIO_S16;
 #endif
 	spec.channels = MIXER_DEFAULT_CHANNELS_COUNT;
-
+	if (g_refKeenCfg.sndLowLatency)
+	{
+		BEL_ST_LowLatencySetup(&spec);
+	}
 	BE_Cross_LogMessage(BE_LOG_MSG_NORMAL, "Initializing audio subsystem, requested spec: freq %d, format %u, channels %d\n", (int)spec.freq, (unsigned int)spec.format, (int)spec.channels);
 	g_sdlAudioStream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, BEL_ST_MixerCallback, 0);
 	if (!g_sdlAudioStream)
@@ -103,11 +144,18 @@ bool BEL_ST_InitAudioSubsystem(int *freq, int *channels, int *bufferLen)
 		return false;
 	}
 #endif
-	BE_Cross_LogMessage(BE_LOG_MSG_NORMAL, "Audio subsystem initialized\n");
+	SDL_AudioSpec devSpec;
+	int sampleFrames;
+	if (!SDL_GetAudioDeviceFormat(SDL_GetAudioStreamDevice(g_sdlAudioStream), &devSpec, &sampleFrames))
+	{
+		devSpec = spec;
+		sampleFrames = g_refKeenCfg.sndSampleRate / 64; // An approximation
+	}
+	BE_Cross_LogMessage(BE_LOG_MSG_NORMAL, "Audio subsystem initialized, audio driver: %s, service rate: ~%fHz\n", SDL_GetCurrentAudioDriver(), (double)devSpec.freq / sampleFrames);
 
 	*freq = spec.freq;
 	*channels = g_sdlAudioChannels = spec.channels;
-	*bufferLen = g_refKeenCfg.sndSampleRate / 64; // An approximation
+	*bufferLen = sampleFrames;
 
 	return true;
 }

--- a/src/backend/cfg/be_cfg.c
+++ b/src/backend/cfg/be_cfg.c
@@ -178,6 +178,7 @@ static BE_ST_CFG_Setting_T g_be_st_settings[] = {
 	DEF_BOOL(showEndoom, "showendoom", true)
 	DEF_ENUM(mouseGrab, "mousegrab", g_be_setting_mousegrab_vals, MOUSEGRAB_AUTO)
 	DEF_INT(sndInterThreadBufferRatio, "sndinterthreadbufferratio", 2, 1, INT_MAX)
+	DEF_BOOL(sndLowLatency, "sndlowlatency", false)
 	// 49716 may lead to unexpected behaviors on Android
 	DEF_INT(sndSampleRate, "sndsamplerate", 48000, 1, INT_MAX)
 	DEF_BOOL(sndSubSystem, "sndsubsystem", true)

--- a/src/be_st_cfg.h
+++ b/src/be_st_cfg.h
@@ -76,6 +76,10 @@ typedef struct
 	int/*bool*/ showEndoom;
 	int mouseGrab;
 	int sndInterThreadBufferRatio;
+	// Low latency audio tries to get close to 700Hz timing on audio callback.
+	// Typically there's no reason for a user to enable this due to emulated
+	// audio devices being flexible on timing.
+	int/*bool*/ sndLowLatency;
 	int sndSampleRate;
 	int/*bool*/ sndSubSystem;
 	int/*bool*/ oplEmulation;


### PR DESCRIPTION
This is in preparation to enabling support for interfacing with hardware DSS which needs probably a 460Hz or higher service routine to function. It has little benefit with emulated sound devices due to not having to deal with wall time, but would technically be a little more accurate. This option is not currently exposed in the launcher as it's not expected there to be a real reason to enable it.

----
In BE_ST_InitAudio the OPL source is added with `2*samplesForSourceBuffer`. I assume this was needed to ensure the buffer is large enough for 8kHz to hold enough register writes, so I based the min size off that.  This means for higher sample rates I've removed the doubling which seems to be fine in the usual "programmers only test map 1" way.